### PR TITLE
start-rpi-capture improvements

### DIFF
--- a/GCS/start_geosearch.sh
+++ b/GCS/start_geosearch.sh
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-geosearch.py --sensorwidth 3.674 --lens 40 --minscore 1000 --roll-stabilised --time-offset 1 --mavlog $1/mav.tlog $1
+geosearch.py --sensorwidth 3.674 --lens 40 --minscore 1000 --roll-stabilised --time-offset 1 --start --mavlog $1/mav.tlog $1

--- a/companion/start_rpi_capture/clear_images.sh
+++ b/companion/start_rpi_capture/clear_images.sh
@@ -12,11 +12,11 @@ then
 fi
 
 echo "pictures before:"
-find $IMAGE_DIR -name "*Z.jpg" | wc -l
+find $IMAGE_DIR -name "*Z.jpg?" | wc -l
 
 echo "clearing pics from $IMAGE_DIR .."
-find $IMAGE_DIR -name "*Z.jpg" -delete
+find $IMAGE_DIR -name "*Z.jpg?" -delete
 
 echo "pictures after:"
-find $IMAGE_DIR -name "*Z.jpg" | wc -l
+find $IMAGE_DIR -name "*Z.jpg?" | wc -l
 

--- a/companion/start_rpi_capture/start_rpi_capture.sh
+++ b/companion/start_rpi_capture/start_rpi_capture.sh
@@ -24,5 +24,9 @@ then
 fi
 
 ## TODO: check param, ISO:400
-raspistill -n -r -ISO 400 -q $QUALITY -v -dt -t 3600000 -tl 0 -o ${IMAGE_DIR}/%dZ.jpg
+while [ 1 ]; do
+    raspistill -n -r -ISO 400 -q $QUALITY -v -dt -t 3600000 -tl 3500 -o ${IMAGE_DIR}/%dZ.jpg
+    echo "*************** raspistill exited, restarting ******************"
+    sleep 1
+done
 

--- a/companion/start_rpi_capture/start_rpi_capture.sh
+++ b/companion/start_rpi_capture/start_rpi_capture.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+# wait 30 seconds to allow APWeb to set system time from the GPS
+sleep 30
+
 QUALITY=100
 
 # create directory for images


### PR DESCRIPTION
This set of commits makes the following changes:

- start-rpi-capture takes pictures every 3.5sec (to improve reliability)
- start-rpi-capture waits 30 seconds before starting to allow APWeb to set the system time from the GPS (note: this requires the latest version of APWeb from Peter Barker to be installed).
- clear-images gets rid of temp jpg files
- start-geosearch starts the analysis immediately instead of forcing the user to click on "Mosaic", "Start"

The changes from Peter Barker to APWeb can be found in this repo: https://github.com/peterbarker/APWeb/commits/apsync.  So to update an RPI which already has APSync on it, you would need to do this:

- cd ~/GitHub
- git clone https://github.com/peterbarker/APWeb.git
- cd APWeb
- git get
- git checkout apsync
- make
- sudo killall -9 web_server
- cp web_server ~/start_apweb/web_server
- sudo reboot now

