### PR TITLE
start_rpi_capture: save images with GMT timestamp

### DIFF
--- a/companion/start_rpi_capture/start_rpi_capture.sh
+++ b/companion/start_rpi_capture/start_rpi_capture.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+# set timezone to GMT
+export TZ=GMT
+
 # wait 30 seconds to allow APWeb to set system time from the GPS
 sleep 30
 


### PR DESCRIPTION
Images should have their filename using GMT time instead of local time.